### PR TITLE
feat: Deprecated declarative screen build

### DIFF
--- a/Sources/Beagle/Sources/Components/ServerDrivenComponent/Screen/Screen.swift
+++ b/Sources/Beagle/Sources/Components/ServerDrivenComponent/Screen/Screen.swift
@@ -19,6 +19,7 @@ import Foundation
 /// The screen element will help you define the screen view structure.
 /// By using this component you can define configurations like whether or
 /// not you want to use safe areas or display a tool bar/navigation bar.
+@available(*, deprecated, message: "Since version 1.10. Declarative screen construction will be removed in 2.0")
 public struct Screen: HasContext {
     
     /// identifies your screen globally inside your application so that it could have actions set on itself.

--- a/Sources/Beagle/Sources/Components/ServerDrivenComponent/ServerDrivenComponent.swift
+++ b/Sources/Beagle/Sources/Components/ServerDrivenComponent/ServerDrivenComponent.swift
@@ -18,6 +18,7 @@ import UIKit
 
 public protocol ServerDrivenComponent: Decodable, Renderable {}
 
+@available(*, deprecated, message: "Since version 1.10. Declarative screen construction will be removed in 2.0")
 public protocol ComposeComponent: ServerDrivenComponent {
     func build() -> ServerDrivenComponent
 }
@@ -29,6 +30,7 @@ extension ComposeComponent {
 }
 
 extension ServerDrivenComponent {
+    @available(*, deprecated, message: "Since version 1.10. Declarative screen construction will be removed in 2.0")
     public func toScreen() -> Screen {
         let screen = self as? ScreenComponent
         let safeArea = screen?.safeArea

--- a/Sources/Beagle/Sources/Renderer/BeagleScreenViewController.swift
+++ b/Sources/Beagle/Sources/Renderer/BeagleScreenViewController.swift
@@ -73,13 +73,25 @@ public class BeagleScreenViewController: BeagleController {
         }
     }
     
+    @available(*, deprecated, message: "Since version 1.10. Declarative screen construction will be removed in 2.0. Use the init with remote or json parameter instead.")
     public convenience init(_ component: ServerDrivenComponent, controllerId: String? = nil) {
         self.init(.declarative(component.toScreen()), controllerId: controllerId)
         self.navigationControllerId = controllerId
     }
     
+    @available(*, deprecated, message: "Since version 1.10. Declarative screen construction will be removed in 2.0. Use the init with remote or json parameter instead.")
     public convenience init(_ screenType: ScreenType, controllerId: String? = nil) {
         self.init(viewModel: .init(screenType: screenType), controllerId: controllerId)
+        self.navigationControllerId = controllerId
+    }
+    
+    public convenience init(_ remote: ScreenType.Remote, controllerId: String? = nil) {
+        self.init(viewModel: .init(screenType: .remote(remote)), controllerId: controllerId)
+        self.navigationControllerId = controllerId
+    }
+    
+    public convenience init(_ json: String, controllerId: String? = nil) {
+        self.init(viewModel: .init(screenType: .declarativeText(json)), controllerId: controllerId)
         self.navigationControllerId = controllerId
     }
     

--- a/Sources/Beagle/Sources/Renderer/BeagleView.swift
+++ b/Sources/Beagle/Sources/Renderer/BeagleView.swift
@@ -29,16 +29,22 @@ public class BeagleView: UIView {
     
     // MARK: - Initialization
     
+    @available(*, deprecated, message: "Since version 1.10. Declarative screen construction will be removed in 2.0. Use the init with remote or json parameter instead.")
     public convenience init(_ component: ServerDrivenComponent) {
         self.init(.declarative(component.toScreen()))
     }
     
+    @available(*, deprecated, message: "Since version 1.10. Declarative screen construction will be removed in 2.0. Use the init with remote or json parameter instead.")
     public convenience init(_ screenType: ScreenType) {
         self.init(viewModel: .init(screenType: screenType))
     }
     
     public convenience init(_ remote: ScreenType.Remote, beagleViewStateObserver: @escaping BeagleViewStateObserver) {
         self.init(viewModel: .init(screenType: .remote(remote), beagleViewStateObserver: beagleViewStateObserver))
+    }
+    
+    public convenience init(_ json: String, beagleViewStateObserver: @escaping BeagleViewStateObserver) {
+        self.init(viewModel: .init(screenType: .declarativeText(json), beagleViewStateObserver: beagleViewStateObserver))
     }
 
     required init(viewModel: BeagleScreenViewModel) {

--- a/Sources/Beagle/Sources/Renderer/ScreenType.swift
+++ b/Sources/Beagle/Sources/Renderer/ScreenType.swift
@@ -19,22 +19,21 @@ public enum ScreenType {
     case declarative(Screen)
     case declarativeText(String)
 
-    public struct Remote: AutoInitiable {
+    public struct Remote {
         let url: String
         let fallback: Screen?
         let additionalData: RemoteScreenAdditionalData?
 
-// sourcery:inline:auto:ScreenType.Remote.Init
-    public init(
-        url: String,
-        fallback: Screen? = nil,
-        additionalData: RemoteScreenAdditionalData? = nil
-    ) {
-        self.url = url
-        self.fallback = fallback
-        self.additionalData = additionalData
-    }
-// sourcery:end
+        @available(*, deprecated, message: "Since version 1.10. Fallback parameter will be removed. Handle your error with serverDrivenStateDidChange in BeagleNavigationController instead")
+        public init(
+            url: String,
+            fallback: Screen? = nil,
+            additionalData: RemoteScreenAdditionalData? = nil
+        ) {
+            self.url = url
+            self.fallback = fallback
+            self.additionalData = additionalData
+        }
     }
 }
 

--- a/Sources/Beagle/Sources/Setup/BeagleSetup.swift
+++ b/Sources/Beagle/Sources/Setup/BeagleSetup.swift
@@ -42,6 +42,7 @@ public func registerCustomAction<A: Action>(
     dependencies.decoder.register(action: actionType, named: name)
 }
 
+@available(*, deprecated, message: "Since version 1.10. Declarative screen construction will be removed in 2.0. Use the BeagleScreenViewController inits with remote or json parameter instead.")
 public func screen(_ type: ScreenType, controllerId: String? = nil) -> BeagleScreenViewController {
     return BeagleScreenViewController(type, controllerId: controllerId)
 }


### PR DESCRIPTION
Signed-off-by: Daniel Tes Carrasque <daniel@zup.com.br>

### Description and Example

Deprecated declarative inits in BeagleView and BeagleScreenViewController, and other declarative only Components as ComposeComponent

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [ ] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/main/doc/contributing/pull_requests.md
