### PR TITLE
feat: Adds root id property to analytics screen record

### DIFF
--- a/Example/BeagleDemo/BeagleDemo/Constants/Constants.swift
+++ b/Example/BeagleDemo/BeagleDemo/Constants/Constants.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Example/BeagleDemo/BeagleDemo/Constants/Constants.swift
+++ b/Example/BeagleDemo/BeagleDemo/Constants/Constants.swift
@@ -34,6 +34,8 @@ extension String {
     static let componentsEndpoint = "/components"
     static let screenDeeplinkEndpoint = "screen-deep-link"
     static let navigateStep1Endpoint = "navigateScreenStep1"
+    static let analyticsRootIdScreen = "https://run.mocky.io/v3/6efac532-e408-422b-87a0-633eaea56d5f"
+    static let analyticsRootIdComponent = "https://run.mocky.io/v3/d77c12a3-f69f-4acf-87b1-3e6f2e0bc0fd"
     static let navigateStep2Endpoint = "navigateScreenStep2"
     static let globalContextEndpoint = "globalContext"
     static let beagleView = "beagleView"

--- a/Example/BeagleDemo/BeagleDemo/Screens/MainScreen.swift
+++ b/Example/BeagleDemo/BeagleDemo/Screens/MainScreen.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Example/BeagleDemo/BeagleDemo/Screens/MainScreen.swift
+++ b/Example/BeagleDemo/BeagleDemo/Screens/MainScreen.swift
@@ -38,6 +38,14 @@ struct MainScreen: DeeplinkScreen {
     private func buildChild() -> ScrollView {
         return ScrollView {
                 Button(
+                    text: "Analytics RootId Screen",
+                    onPress: [Navigate.pushView(.remote(.init(url: .analyticsRootIdScreen)))]
+                )
+                Button(
+                    text: "Analytics RootId Component",
+                    onPress: [Navigate.pushView(.remote(.init(url: .analyticsRootIdComponent)))]
+                )
+                Button(
                     text: "Navigator",
                     onPress: [Navigate.openNativeRoute(.init(route: .navigateStep1Endpoint))]
                 )

--- a/Sources/Beagle/Sources/Analytics/AnalyticsRecord.swift
+++ b/Sources/Beagle/Sources/Analytics/AnalyticsRecord.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/Beagle/Sources/Analytics/AnalyticsRecord.swift
+++ b/Sources/Beagle/Sources/Analytics/AnalyticsRecord.swift
@@ -21,6 +21,7 @@ public struct AnalyticsRecord {
     public let platform = "ios"
     public let screen: String?
     public var timestamp: Double
+    public var rootId: String?
 
     public var type: RecordType
 
@@ -29,12 +30,13 @@ public struct AnalyticsRecord {
         case action(Action)
     }
     
-    public init(type: RecordType, screen: String?, timestamp: Double) {
+    public init(type: RecordType, screen: String?, timestamp: Double, rootId: String? = nil) {
         self.type = type
         self.screen = screen
         self.timestamp = timestamp
+        self.rootId = rootId
     }
-
+    
     public struct Action {
         public var beagleAction: String
         public var event: String?
@@ -68,11 +70,15 @@ extension AnalyticsRecord {
 
         case .screen:
             dict["type"] = "screen"
+            if let rootId = rootId {
+                dict["rootId"] = .string(rootId)
+            }
         }
 
         screen.map { dict["screen"] = .string($0) }
         dict["platform"] = .string(platform)
         dict["timestamp"] = .double(timestamp)
+        
         return dict
     }
 }

--- a/Sources/Beagle/Sources/Analytics/Service/AnalyticsService.swift
+++ b/Sources/Beagle/Sources/Analytics/Service/AnalyticsService.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/Beagle/Sources/Analytics/Service/AnalyticsService.swift
+++ b/Sources/Beagle/Sources/Analytics/Service/AnalyticsService.swift
@@ -30,9 +30,10 @@ class AnalyticsService {
 
     // MARK: - Create Events
 
-    func createRecord(screen: ScreenType) {
+    func createRecord(screen: ScreenType, rootId:String? = nil) {
         makeScreenRecord(
             screen: screen,
+            rootId: rootId,
             isScreenEnabled: provider.getConfig().enableScreenAnalytics
         )
         .ifSome(provider.createRecord(_:))

--- a/Sources/Beagle/Sources/Analytics/Service/RecordFactory.swift
+++ b/Sources/Beagle/Sources/Analytics/Service/RecordFactory.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/Beagle/Sources/Analytics/Service/RecordFactory.swift
+++ b/Sources/Beagle/Sources/Analytics/Service/RecordFactory.swift
@@ -21,11 +21,12 @@ import UIKit
 
 func makeScreenRecord(
     screen: ScreenType,
+    rootId: String? = nil,
     isScreenEnabled: Bool
 ) -> AnalyticsRecord? {
     guard isScreenEnabled else { return nil }
 
-    return AnalyticsRecord(type: .screen, screen: screenInfo(screen), timestamp: timestamp())
+    return AnalyticsRecord(type: .screen, screen: screenInfo(screen), timestamp: timestamp(), rootId: rootId)
 }
 
 // MARK: Action

--- a/Sources/Beagle/Sources/Components/ServerDrivenComponent/Screen/Screen.swift
+++ b/Sources/Beagle/Sources/Components/ServerDrivenComponent/Screen/Screen.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/Beagle/Sources/Components/ServerDrivenComponent/Screen/Screen.swift
+++ b/Sources/Beagle/Sources/Components/ServerDrivenComponent/Screen/Screen.swift
@@ -22,6 +22,7 @@ import Foundation
 @available(*, deprecated, message: "Since version 1.10. Declarative screen construction will be removed in 2.0")
 public struct Screen: HasContext {
     
+    @available(*, deprecated, message: "Since version 1.10, identifier property has been deprecated, avoid using Screen as it will be removed in version 2.0")
     /// identifies your screen globally inside your application so that it could have actions set on itself.
     public let identifier: String?
     

--- a/Sources/Beagle/Sources/Components/ServerDrivenComponent/ServerDrivenComponent.swift
+++ b/Sources/Beagle/Sources/Components/ServerDrivenComponent/ServerDrivenComponent.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/Beagle/Sources/Components/ServerDrivenComponent/ServerDrivenComponent.swift
+++ b/Sources/Beagle/Sources/Components/ServerDrivenComponent/ServerDrivenComponent.swift
@@ -48,7 +48,7 @@ extension ServerDrivenComponent {
             )
         } else {
             return Screen(
-                identifier: screen?.identifier,
+                identifier: screen?.identifier ?? getFirstChildContainerId(),
                 style: screen?.style,
                 safeArea: safeArea,
                 navigationBar: screen?.navigationBar,
@@ -56,6 +56,11 @@ extension ServerDrivenComponent {
                 context: screen?.context
             )
         }
+    }
+    
+    private func getFirstChildContainerId() -> String? {
+        let child = self as? Beagle.Container
+        return child?.id
     }
 }
 

--- a/Sources/Beagle/Sources/Renderer/BeagleScreenViewModel.swift
+++ b/Sources/Beagle/Sources/Renderer/BeagleScreenViewModel.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/Beagle/Sources/Renderer/BeagleScreenViewModel.swift
+++ b/Sources/Beagle/Sources/Renderer/BeagleScreenViewModel.swift
@@ -98,7 +98,9 @@ class BeagleScreenViewModel {
             screenAppearEventIsPending = false
             dependencies.analytics?.trackEventOnScreenAppeared(event)
         }
-        AnalyticsService.shared?.createRecord(screen: screenType)
+        
+        AnalyticsService.shared?.createRecord(screen: screenType, rootId: screen?.identifier)
+                
     }
     
     public func trackEventOnScreenDisappeared() {

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 ﻿{
-  "**/*.*": [
+  "copyright": [
     "Copyright",
     "ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA",
     "Licensed under the Apache License, Version 2.0 (the \"License\");",


### PR DESCRIPTION
Signed-off-by: Hector <hector.custodio@zup.com.br>


### Related Issues
Closes https://github.com/ZupIT/beagle/issues/1793

<!--
- list all issues that are related to this PR (e.g: "#123, #124)
- if this PR closes some issue, use "Closes #123"
-->

### Description and Example

This PR adds a new property to the screen analytics record called ``rootId``. This property should be on the record of screen events and its value is the identifier (In case of the deprecated Screen Component) or the id of the first component of the current Tree presented in the Application.
<!--
- if related issues don't already describe the problem you are trying to solve (and why it's important), please say it here
- try to give a small example of the most imporant thing you actually changed (code snippets, screenshots, file name, and others are welcomed)
-->

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [x] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/main/doc/contributing/pull_requests.md
