### PR TITLE
fix: screen background color

### DIFF
--- a/Sources/Beagle/Sources/Renderer/BeagleScreenViewController.swift
+++ b/Sources/Beagle/Sources/Renderer/BeagleScreenViewController.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/Beagle/Sources/Renderer/BeagleScreenViewController.swift
+++ b/Sources/Beagle/Sources/Renderer/BeagleScreenViewController.swift
@@ -220,6 +220,14 @@ public class BeagleScreenViewController: BeagleController {
         }
     }
     
+    private func updateScreenStyle() {
+        renderer.observe(screen?.style?.backgroundColor, andUpdateManyIn: view) { [weak self] value in
+            if let hex = value {
+                self?.view.backgroundColor = UIColor(hex: hex)
+            }
+        }
+    }
+    
     // MARK: - Update View
     
     fileprivate func updateView(state: ServerDrivenState) {
@@ -242,6 +250,7 @@ public class BeagleScreenViewController: BeagleController {
     private func renderScreenIfNeeded() {
         if content == nil, let screen = screen {
             updateNavigationBar(animated: true)
+            updateScreenStyle()
             content = .view(renderer.render(screen))
         }
     }


### PR DESCRIPTION
### Description and Example

Screen background color does not work as expected when colors with alpha less than 1 are passed.

`backgroundColor = "#00000000"` for example, when we want to show the content of the screen behind the current screen.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [ ] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/main/doc/contributing/pull_requests.md
