### PR TITLE
fix: Accessibility trait config in applyAccessibility

### DIFF
--- a/Sources/Beagle/BeagleTests/Renderer/ViewConfiguratorTests.swift
+++ b/Sources/Beagle/BeagleTests/Renderer/ViewConfiguratorTests.swift
@@ -66,4 +66,25 @@ class ViewConfiguratorTests: XCTestCase {
         XCTAssertNotEqual(view.layer.borderWidth, CGFloat(borderWidthValue))
         XCTAssertNotEqual(view.layer.borderColor, UIColor(hex: borderColorHex)?.cgColor)
     }
+    
+    func testApplyAccessibility() {
+        // Given
+        let button = UIButton()
+        button.accessibilityTraits = .button
+        let buttonHeader = UIButton()
+        var accessibility = Accessibility(accessibilityLabel: "accessibilityLabel", accessible: true)
+        
+        // When
+        ViewConfigurator.applyAccessibility(accessibility, to: button)
+        accessibility.isHeader = true
+        ViewConfigurator.applyAccessibility(accessibility, to: buttonHeader)
+        
+        // Then
+        XCTAssertEqual(button.accessibilityLabel, accessibility.accessibilityLabel)
+        XCTAssertTrue(button.isAccessibilityElement)
+        XCTAssertEqual(button.accessibilityTraits, .button)
+        XCTAssertEqual(buttonHeader.accessibilityLabel, accessibility.accessibilityLabel)
+        XCTAssertTrue(buttonHeader.isAccessibilityElement)
+        XCTAssertEqual(buttonHeader.accessibilityTraits, .header)
+    }
 }

--- a/Sources/Beagle/Sources/Renderer/ViewConfigurator.swift
+++ b/Sources/Beagle/Sources/Renderer/ViewConfigurator.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/Beagle/Sources/Renderer/ViewConfigurator.swift
+++ b/Sources/Beagle/Sources/Renderer/ViewConfigurator.swift
@@ -100,8 +100,8 @@ class ViewConfigurator: ViewConfiguratorProtocol {
         }
         object?.isAccessibilityElement = accessibility.accessible
         
-        if let isHeader = accessibility.isHeader {
-            object?.accessibilityTraits = isHeader ? .header : .none
+        if let isHeader = accessibility.isHeader, isHeader {
+            object?.accessibilityTraits = .header
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Daniel Tes Carrasque <daniel@zup.com.br>


### Related Issues

[#1803](https://github.com/ZupIT/beagle/issues/1803)

### Description and Example

Fixes a bug in accessibility component configuration when _isHeader_ is set to **false**

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [ ] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/main/doc/contributing/pull_requests.md
