### PR TITLE
feat: create ImageProvider to load dynamic image resources

### DIFF
--- a/Sources/Beagle/Beagle.xcodeproj/project.pbxproj
+++ b/Sources/Beagle/Beagle.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		7CC2D9B424C614FB0059D5F9 /* TabBar+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC2D9B324C614FB0059D5F9 /* TabBar+Extensions.swift */; };
 		7CC2D9B624C6150E0059D5F9 /* TabBarUIComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC2D9B524C6150E0059D5F9 /* TabBarUIComponent.swift */; };
 		7CFE3A752412E3B50087F664 /* StyleBuildersExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CFE3A742412E3B50087F664 /* StyleBuildersExtension.swift */; };
+		8A4DFEF02862548000C205A4 /* ImageProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4DFEEF2862548000C205A4 /* ImageProviderProtocol.swift */; };
 		931B6E302375BA7400DE73FD /* ThemeProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931B6E2F2375BA7400DE73FD /* ThemeProtocol.swift */; };
 		931B6E32237610B300DE73FD /* FunctiontalUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931B6E31237610B300DE73FD /* FunctiontalUtils.swift */; };
 		9322336526CC23FC00CB95EF /* ActionSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9322336426CC23FC00CB95EF /* ActionSpy.swift */; };
@@ -349,6 +350,7 @@
 		7CC2D9B324C614FB0059D5F9 /* TabBar+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TabBar+Extensions.swift"; sourceTree = "<group>"; };
 		7CC2D9B524C6150E0059D5F9 /* TabBarUIComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarUIComponent.swift; sourceTree = "<group>"; };
 		7CFE3A742412E3B50087F664 /* StyleBuildersExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleBuildersExtension.swift; sourceTree = "<group>"; };
+		8A4DFEEF2862548000C205A4 /* ImageProviderProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageProviderProtocol.swift; sourceTree = "<group>"; };
 		931B6E2F2375BA7400DE73FD /* ThemeProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeProtocol.swift; sourceTree = "<group>"; };
 		931B6E31237610B300DE73FD /* FunctiontalUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctiontalUtils.swift; sourceTree = "<group>"; };
 		9322336426CC23FC00CB95EF /* ActionSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionSpy.swift; sourceTree = "<group>"; };
@@ -1677,6 +1679,7 @@
 		A9C6F546273312AD00576313 /* Bundle */ = {
 			isa = PBXGroup;
 			children = (
+				8A4DFEEF2862548000C205A4 /* ImageProviderProtocol.swift */,
 				A9C6F547273312BA00576313 /* BundleProtocol.swift */,
 			);
 			path = Bundle;
@@ -2328,6 +2331,7 @@
 				C08D4E1E24857B4800AAAC0A /* Container+Extensions.swift in Sources */,
 				E52236CD23745E8E00E555BB /* ListViewUIComponent.swift in Sources */,
 				E522377D237C3C5500E555BB /* Touchable+Extensions.swift in Sources */,
+				8A4DFEF02862548000C205A4 /* ImageProviderProtocol.swift in Sources */,
 				C08D4E3224857C7700AAAC0A /* DependencyURLOpener.swift in Sources */,
 				E522377B237C3C5500E555BB /* ServerDrivenComponent.swift in Sources */,
 				9398CA7825532E5E0003A010 /* PageView.swift in Sources */,

--- a/Sources/Beagle/BeagleTests/Components/ServerDrivenComponent/Screen/ScreenComponentTests.swift
+++ b/Sources/Beagle/BeagleTests/Components/ServerDrivenComponent/Screen/ScreenComponentTests.swift
@@ -61,6 +61,7 @@ final class ScreenComponentTests: EnviromentTestCase {
     
     func test_navigationBarButtonItemWithImage() {
         enviroment.appBundle.bundle = Bundle(for: ScreenComponentTests.self)
+        enviroment.imageProvider = ImageProvider(appBundle: enviroment.appBundle)
         let barItem = NavigationBarItem(image: "shuttle", text: "shuttle", onPress: [ActionDummy()])
         
         let component = Screen(
@@ -88,7 +89,8 @@ final class ScreenComponentTests: EnviromentTestCase {
     
     func testNavigationBarItemWithContextOnImage() {
         // Given
-        let bundle = Bundle(for: ScreenComponentTests.self)
+        enviroment.appBundle.bundle = Bundle(for: ScreenComponentTests.self)
+        enviroment.imageProvider = ImageProvider(appBundle: enviroment.appBundle)
         
         let barItem = NavigationBarItem(image: "@{image}", text: "", onPress: [ActionDummy()])
         
@@ -103,9 +105,7 @@ final class ScreenComponentTests: EnviromentTestCase {
         let controller = BeagleScreenViewController(viewModel: .init(
             screenType: .declarative(screen)
         ))
-        
-        controller.renderer.mainBundle.bundle = bundle
-        
+                
         // Then
         assertSnapshotImage(controller.view, size: .custom(CGSize(width: 150, height: 80)))
     }

--- a/Sources/Beagle/BeagleTests/Components/ServerDrivenComponent/Screen/ScreenComponentTests.swift
+++ b/Sources/Beagle/BeagleTests/Components/ServerDrivenComponent/Screen/ScreenComponentTests.swift
@@ -61,7 +61,7 @@ final class ScreenComponentTests: EnviromentTestCase {
     
     func test_navigationBarButtonItemWithImage() {
         enviroment.appBundle.bundle = Bundle(for: ScreenComponentTests.self)
-        enviroment.imageProvider = ImageProvider(appBundle: enviroment.appBundle)
+        enviroment.imageProvider = ImageProvider()
         let barItem = NavigationBarItem(image: "shuttle", text: "shuttle", onPress: [ActionDummy()])
         
         let component = Screen(
@@ -90,7 +90,7 @@ final class ScreenComponentTests: EnviromentTestCase {
     func testNavigationBarItemWithContextOnImage() {
         // Given
         enviroment.appBundle.bundle = Bundle(for: ScreenComponentTests.self)
-        enviroment.imageProvider = ImageProvider(appBundle: enviroment.appBundle)
+        enviroment.imageProvider = ImageProvider()
         
         let barItem = NavigationBarItem(image: "@{image}", text: "", onPress: [ActionDummy()])
         

--- a/Sources/Beagle/BeagleTests/Components/ServerDrivenComponent/TabBar/TabBarTests.swift
+++ b/Sources/Beagle/BeagleTests/Components/ServerDrivenComponent/TabBar/TabBarTests.swift
@@ -23,7 +23,7 @@ class TabBarTests: EnviromentTestCase {
     override func setUp() {
         super.setUp()
         enviroment.appBundle.bundle = Bundle(for: TabBarTests.self)
-        enviroment.imageProvider = ImageProvider(appBundle: enviroment.appBundle)
+        enviroment.imageProvider = ImageProvider()
     }
 
     lazy var controller = BeagleControllerStub()

--- a/Sources/Beagle/BeagleTests/Components/ServerDrivenComponent/TabBar/TabBarTests.swift
+++ b/Sources/Beagle/BeagleTests/Components/ServerDrivenComponent/TabBar/TabBarTests.swift
@@ -23,6 +23,7 @@ class TabBarTests: EnviromentTestCase {
     override func setUp() {
         super.setUp()
         enviroment.appBundle.bundle = Bundle(for: TabBarTests.self)
+        enviroment.imageProvider = ImageProvider(appBundle: enviroment.appBundle)
     }
 
     lazy var controller = BeagleControllerStub()

--- a/Sources/Beagle/BeagleTests/Components/Widget/Image/ImageTests.swift
+++ b/Sources/Beagle/BeagleTests/Components/Widget/Image/ImageTests.swift
@@ -23,6 +23,7 @@ class ImageTests: EnviromentTestCase {
     override func setUp() {
         super.setUp()
         enviroment.appBundle.bundle = Bundle(for: ImageTests.self)
+        enviroment.imageProvider = ImageProvider(appBundle: enviroment.appBundle)
     }
     
     lazy var controller = BeagleControllerStub()

--- a/Sources/Beagle/BeagleTests/Components/Widget/Image/ImageTests.swift
+++ b/Sources/Beagle/BeagleTests/Components/Widget/Image/ImageTests.swift
@@ -23,7 +23,7 @@ class ImageTests: EnviromentTestCase {
     override func setUp() {
         super.setUp()
         enviroment.appBundle.bundle = Bundle(for: ImageTests.self)
-        enviroment.imageProvider = ImageProvider(appBundle: enviroment.appBundle)
+        enviroment.imageProvider = ImageProvider()
     }
     
     lazy var controller = BeagleControllerStub()

--- a/Sources/Beagle/BeagleTests/Helpers/TestEnviroment.swift
+++ b/Sources/Beagle/BeagleTests/Helpers/TestEnviroment.swift
@@ -39,6 +39,7 @@ class TestEnviroment: DependenciesContainerResolving, EnviromentProtocol {
     var analyticsProvider: AnalyticsProviderProtocol?
     var deepLinkHandler: DeepLinkScreenManagerProtocol?
     var networkClient: NetworkClientProtocol?
+    var imageProvider: ImageProviderProtocol = ImageProvider(appBundle: MainBundle())
     
     // MARK: - Builders
     
@@ -72,7 +73,8 @@ class TestEnviroment: DependenciesContainerResolving, EnviromentProtocol {
         mapKey(for: LoggerProtocol.self): { self.logger },
         mapKey(for: NetworkClientProtocol.self): { self.networkClient },
         mapKey(for: DeepLinkScreenManagerProtocol.self): { self.deepLinkHandler },
-        mapKey(for: AnalyticsProviderProtocol.self): { self.analyticsProvider }
+        mapKey(for: AnalyticsProviderProtocol.self): { self.analyticsProvider },
+        mapKey(for: ImageProviderProtocol.self): { self.imageProvider }
     ]
     
     // MARK: - DependenciesContainerResolving

--- a/Sources/Beagle/BeagleTests/Helpers/TestEnviroment.swift
+++ b/Sources/Beagle/BeagleTests/Helpers/TestEnviroment.swift
@@ -39,7 +39,7 @@ class TestEnviroment: DependenciesContainerResolving, EnviromentProtocol {
     var analyticsProvider: AnalyticsProviderProtocol?
     var deepLinkHandler: DeepLinkScreenManagerProtocol?
     var networkClient: NetworkClientProtocol?
-    var imageProvider: ImageProviderProtocol = ImageProvider(appBundle: MainBundle())
+    var imageProvider: ImageProviderProtocol = ImageProvider()
     
     // MARK: - Builders
     

--- a/Sources/Beagle/BeagleTests/Setup/DependenciesContainerTests.swift
+++ b/Sources/Beagle/BeagleTests/Setup/DependenciesContainerTests.swift
@@ -26,7 +26,7 @@ final class DependenciesContainerTests: XCTestCase {
         var dependencies = BeagleDependencies()
         // swiftlint:disable discouraged_direct_init
         dependencies.appBundle.bundle = Bundle()
-        dependencies.imageProvider = ImageProvider(appBundle: dependencies.appBundle)
+        dependencies.imageProvider = ImageProvider()
         
         return DependenciesContainer(dependencies: dependencies)
     }()

--- a/Sources/Beagle/BeagleTests/Setup/DependenciesContainerTests.swift
+++ b/Sources/Beagle/BeagleTests/Setup/DependenciesContainerTests.swift
@@ -26,6 +26,7 @@ final class DependenciesContainerTests: XCTestCase {
         var dependencies = BeagleDependencies()
         // swiftlint:disable discouraged_direct_init
         dependencies.appBundle.bundle = Bundle()
+        dependencies.imageProvider = ImageProvider(appBundle: dependencies.appBundle)
         
         return DependenciesContainer(dependencies: dependencies)
     }()
@@ -47,6 +48,7 @@ final class DependenciesContainerTests: XCTestCase {
         customDependencies.imageDownloader = ImageDownloaderDummy()
         customDependencies.theme = AppThemeDummy()
         customDependencies.viewClient = ViewClientDummy()
+        customDependencies.imageProvider = ImageProviderDummy()
         
         let sut = DependenciesContainer(dependencies: customDependencies)
         

--- a/Sources/Beagle/BeagleTests/Setup/DependenciesDummies.swift
+++ b/Sources/Beagle/BeagleTests/Setup/DependenciesDummies.swift
@@ -210,3 +210,9 @@ class ViewClientDummy: ViewClientProtocol {
         // Intentionally unimplemented...
     }
 }
+
+final class ImageProviderDummy: ImageProviderProtocol {
+    func loadImageProvider(id: String) -> UIImage? {
+        return nil
+    }
+}

--- a/Sources/Beagle/BeagleTests/Setup/__Snapshots__/DependenciesContainerTests/testCustomDependencies.1.txt
+++ b/Sources/Beagle/BeagleTests/Setup/__Snapshots__/DependenciesContainerTests/testCustomDependencies.1.txt
@@ -1,5 +1,5 @@
 ▿ DependenciesContainer
-  ▿ instancesMap: 16 key/value pairs
+  ▿ instancesMap: 17 key/value pairs
     ▿ (2 elements)
       - key: "AnalyticsProviderProtocol"
       ▿ value: DependencyResolver
@@ -27,6 +27,11 @@
           - block: (Function)
     ▿ (2 elements)
       - key: "ImageDownloaderProtocol"
+      ▿ value: DependencyResolver
+        ▿ factory: (1 element)
+          - block: (Function)
+    ▿ (2 elements)
+      - key: "ImageProviderProtocol"
       ▿ value: DependencyResolver
         ▿ factory: (1 element)
           - block: (Function)

--- a/Sources/Beagle/BeagleTests/Setup/__Snapshots__/DependenciesContainerTests/testDefaultDependencies.1.txt
+++ b/Sources/Beagle/BeagleTests/Setup/__Snapshots__/DependenciesContainerTests/testDefaultDependencies.1.txt
@@ -1,5 +1,5 @@
 ▿ DependenciesContainer
-  ▿ instancesMap: 13 key/value pairs
+  ▿ instancesMap: 14 key/value pairs
     ▿ (2 elements)
       - key: "BundleProtocol"
       ▿ value: DependencyResolver
@@ -17,6 +17,11 @@
           - block: (Function)
     ▿ (2 elements)
       - key: "ImageDownloaderProtocol"
+      ▿ value: DependencyResolver
+        ▿ factory: (1 element)
+          - block: (Function)
+    ▿ (2 elements)
+      - key: "ImageProviderProtocol"
       ▿ value: DependencyResolver
         ▿ factory: (1 element)
           - block: (Function)

--- a/Sources/Beagle/Sources/Bundle/ImageProviderProtocol.swift
+++ b/Sources/Beagle/Sources/Bundle/ImageProviderProtocol.swift
@@ -1,0 +1,34 @@
+//
+/*
+ * Copyright 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import UIKit
+
+public protocol ImageProviderProtocol {
+    func loadImageProvider(id: String) -> UIImage?
+}
+
+public struct ImageProvider : ImageProviderProtocol {
+    let bundle : Bundle
+    
+    public init(appBundle : BundleProtocol) {
+        self.bundle = appBundle.bundle
+    }
+    
+    public func loadImageProvider(id: String) -> UIImage? {
+        return UIImage(named: id, in: self.bundle, compatibleWith: nil)
+    }
+}

--- a/Sources/Beagle/Sources/Bundle/ImageProviderProtocol.swift
+++ b/Sources/Beagle/Sources/Bundle/ImageProviderProtocol.swift
@@ -1,6 +1,5 @@
-//
 /*
- * Copyright 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,14 +20,10 @@ public protocol ImageProviderProtocol {
     func loadImageProvider(id: String) -> UIImage?
 }
 
-public struct ImageProvider : ImageProviderProtocol {
-    let bundle : Bundle
+struct ImageProvider : ImageProviderProtocol {
+    @Injected var mainBundle : BundleProtocol
     
-    public init(appBundle : BundleProtocol) {
-        self.bundle = appBundle.bundle
-    }
-    
-    public func loadImageProvider(id: String) -> UIImage? {
-        return UIImage(named: id, in: self.bundle, compatibleWith: nil)
+     func loadImageProvider(id: String) -> UIImage? {
+        return UIImage(named: id, in: self.mainBundle.bundle, compatibleWith: nil)
     }
 }

--- a/Sources/Beagle/Sources/Components/ServerDrivenComponent/Screen/NavigationBar+UIKit.swift
+++ b/Sources/Beagle/Sources/Components/ServerDrivenComponent/Screen/NavigationBar+UIKit.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/Beagle/Sources/Components/ServerDrivenComponent/Screen/NavigationBar+UIKit.swift
+++ b/Sources/Beagle/Sources/Components/ServerDrivenComponent/Screen/NavigationBar+UIKit.swift
@@ -57,11 +57,7 @@ extension NavigationBarItem {
             if let renderer = controller?.renderer {
                 renderer.observe(expression, andUpdateManyIn: view) { icon in
                     guard let icon = icon else { return }
-                    self.image = UIImage(
-                        named: icon,
-                        in: renderer.appBundle,
-                        compatibleWith: nil
-                    )?.withRenderingMode(.alwaysOriginal)
+                    self.image = renderer.imageProvider.loadImageProvider(id: icon)?.withRenderingMode(.alwaysOriginal)
                 }
             }
         }

--- a/Sources/Beagle/Sources/Components/ServerDrivenComponent/TabBar/TabBar.swift
+++ b/Sources/Beagle/Sources/Components/ServerDrivenComponent/TabBar/TabBar.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/Beagle/Sources/Components/ServerDrivenComponent/TabBar/TabBarItemUIComponent.swift
+++ b/Sources/Beagle/Sources/Components/ServerDrivenComponent/TabBar/TabBarItemUIComponent.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/Beagle/Sources/Components/ServerDrivenComponent/TabBar/TabBarItemUIComponent.swift
+++ b/Sources/Beagle/Sources/Components/ServerDrivenComponent/TabBar/TabBarItemUIComponent.swift
@@ -129,8 +129,8 @@ final class TabBarItemUIComponent: UIView {
             guard let self = self else { return }
             if let icon = icon {
                 self.icon.image = self.theme?.selectedIconColor == nil ?
-                    UIImage(named: icon, in: self.renderer?.appBundle, compatibleWith: nil) :
-                    UIImage(named: icon, in: self.renderer?.appBundle, compatibleWith: nil)?.withRenderingMode(.alwaysTemplate)
+                self.renderer?.imageProvider.loadImageProvider(id: icon) :
+                self.renderer?.imageProvider.loadImageProvider(id: icon)?.withRenderingMode(.alwaysTemplate)
             }
         }
     }

--- a/Sources/Beagle/Sources/Components/Widget/Image/Image+Extensions.swift
+++ b/Sources/Beagle/Sources/Components/Widget/Image/Image+Extensions.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/Beagle/Sources/Components/Widget/Image/Image+Extensions.swift
+++ b/Sources/Beagle/Sources/Components/Widget/Image/Image+Extensions.swift
@@ -37,7 +37,7 @@ extension Image {
             let expression: Expression<String> = "\(mobileId)"
             renderer.observe(expression, andUpdateManyIn: image) { mobileId in
                 guard let mobileId = mobileId, !mobileId.isEmpty else { return }
-                self.setImageFromAsset(named: mobileId, bundle: renderer.appBundle, imageView: image)
+                self.setImageFromAsset(named: mobileId, imageView: image, renderer: renderer)
             }
         case .remote(let remote):
             let expression: Expression<String> = "\(remote.url)"
@@ -54,7 +54,7 @@ extension Image {
             image.token?.cancel()
             switch path {
             case .local(let mobileId):
-                self.setImageFromAsset(named: mobileId, bundle: renderer.appBundle, imageView: image)
+                self.setImageFromAsset(named: mobileId, imageView: image, renderer: renderer)
             case .remote(let remote):
                 image.token = self.setRemoteImage(from: remote.url, placeholder: remote.placeholder, imageView: image, renderer: renderer)
             case .none: ()
@@ -62,14 +62,14 @@ extension Image {
         }
     }
 
-    private func setImageFromAsset(named: String, bundle: Bundle, imageView: UIImageView) {
-        imageView.image = UIImage(named: named, in: bundle, compatibleWith: nil)
+    private func setImageFromAsset(named: String, imageView: UIImageView, renderer : BeagleRenderer) {
+        imageView.image = renderer.imageProvider.loadImageProvider(id: named)
     }
 
     private func setRemoteImage(from url: String, placeholder: String?, imageView: UIImageView, renderer: BeagleRenderer) -> RequestToken? {
         var imagePlaceholder: UIImage?
         if let placeholder = placeholder {
-            imagePlaceholder = UIImage(named: placeholder, in: renderer.appBundle, compatibleWith: nil)
+            imagePlaceholder = renderer.imageProvider.loadImageProvider(id: placeholder)
             imageView.image = imagePlaceholder
         }
         return lazyLoadImage(path: url, placeholderImage: imagePlaceholder, imageView: imageView, renderer: renderer)

--- a/Sources/Beagle/Sources/Renderer/BeagleRenderer.swift
+++ b/Sources/Beagle/Sources/Renderer/BeagleRenderer.swift
@@ -28,6 +28,7 @@ public struct BeagleRenderer {
     @Injected public var mainBundle: BundleProtocol
     @Injected public var preFetchHelper: PrefetchHelperProtocol
     @Injected public var imageDownloader: ImageDownloaderProtocol
+    @Injected public var imageProvider: ImageProviderProtocol
 
     // MARK: Properties
     

--- a/Sources/Beagle/Sources/Setup/BeagleConfigurator.swift
+++ b/Sources/Beagle/Sources/Setup/BeagleConfigurator.swift
@@ -39,6 +39,7 @@ public struct BeagleDependencies {
     public var analyticsProvider: AnalyticsProviderProtocol?
     public var deepLinkHandler: DeepLinkScreenManagerProtocol?
     public var networkClient: NetworkClientProtocol?
+    public var imageProvider: ImageProviderProtocol = ImageProvider(appBundle: MainBundle())
     
     // MARK: Public Dependencies
     public var appBundle: BundleProtocol = MainBundle()

--- a/Sources/Beagle/Sources/Setup/BeagleConfigurator.swift
+++ b/Sources/Beagle/Sources/Setup/BeagleConfigurator.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ public struct BeagleDependencies {
     public var analyticsProvider: AnalyticsProviderProtocol?
     public var deepLinkHandler: DeepLinkScreenManagerProtocol?
     public var networkClient: NetworkClientProtocol?
-    public var imageProvider: ImageProviderProtocol = ImageProvider(appBundle: MainBundle())
+    public var imageProvider: ImageProviderProtocol = ImageProvider()
     
     // MARK: Public Dependencies
     public var appBundle: BundleProtocol = MainBundle()

--- a/Sources/Beagle/Sources/Setup/DependenciesContainer.swift
+++ b/Sources/Beagle/Sources/Setup/DependenciesContainer.swift
@@ -97,6 +97,7 @@ final class DependenciesContainer: DependenciesContainerResolving {
         registerFactory(ThemeProtocol.self, block: dependencies.theme)
         registerFactory(ViewClientProtocol.self, block: dependencies.viewClient)
         registerFactory(ImageDownloaderProtocol.self, block: dependencies.imageDownloader)
+        registerFactory(ImageProviderProtocol.self, block: dependencies.imageProvider)
         
         if let analyticsProvider = dependencies.analyticsProvider {
             registerLazy(AnalyticsProviderProtocol.self, block: analyticsProvider)

--- a/Sources/Beagle/Sources/Setup/DependenciesContainer.swift
+++ b/Sources/Beagle/Sources/Setup/DependenciesContainer.swift
@@ -1,6 +1,5 @@
-//
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Related Issues

Closes https://github.com/ZupIT/beagle/issues/1816

### Description and Example

To facilitate the process of loading images from multi-module projects in Beagle for iOS, a new protocol to create an ImageProvider, similar how is done in Android, would allow us to load resources from more than one bounded Bundle context.

```swift
public protocol ImageAssetProtocol {
    func loadImageAsset(id: String) -> UIImage?
} 
 ```
### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.
- [X] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/main/doc/contributing/pull_requests.md
