### PR TITLE
fix: iOS 16 beta workaround for removeSubrange

### DIFF
--- a/Sources/Beagle/BeagleTests/Common/Util/Snapshot.swift
+++ b/Sources/Beagle/BeagleTests/Common/Util/Snapshot.swift
@@ -19,7 +19,7 @@ import Beagle
 import SnapshotTesting
 
 private let imageDiffPrecision: Float = 0.99
-private let diffTool = "code"
+private let diffTool = "code --diff"
 
 enum ImageSize {
     case standard

--- a/Sources/Beagle/Sources/ContextExpression/Expression/Parser.swift
+++ b/Sources/Beagle/Sources/ContextExpression/Expression/Parser.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/Beagle/Sources/ContextExpression/Expression/Parser.swift
+++ b/Sources/Beagle/Sources/ContextExpression/Expression/Parser.swift
@@ -69,10 +69,20 @@ func literal(string: String) -> Parser<Void> {
 }
 
 func prefix(with regex: String) -> Parser<String> {
-    return Parser<String> { str in
-        guard let range = str.range(of: regex, options: [.regularExpression, .anchored]) else { return nil }
-        let prefix = str[range]
-        str.removeSubrange(range)
+    return Parser<String> { substring in
+        guard let rangeOfSubstring = substring.range(of: regex, options: [.regularExpression, .anchored]) else { return nil }
+        let prefix = substring[rangeOfSubstring]
+        
+        // TODO: Remove this workaround when removeSubrange is fixed by Apple
+        if #available(iOS 16.0, *) {
+            var string = String(substring)
+            guard let rangeOfString = string.range(of: regex, options: [.regularExpression, .anchored]) else { return nil }
+            string.removeSubrange(rangeOfString)
+            substring = string[...]
+        } else {
+            substring.removeSubrange(rangeOfSubstring)
+        }
+        
         return String(prefix)
     }
 }


### PR DESCRIPTION
Signed-off-by: Daniel Tes Carrasque <daniel@zup.com.br>

### Description and Example

Create a workaround for a bug found in iOS 16 beta. This bug is related to removeSubrange for Substrings:

Reproducing:
```swift
var sub = "a"[...]
sub.removeSubrange(sub.startIndex..<sub.endIndex) 
// Swift/StringGraphemeBreaking.swift:458: 
// Fatal error: Unexpectedly found nil while unwrapping an Optional value
```

We use Substring in Parser implementation because of its performance advantage.

The workaround proposed in this pr will be removed when the bug is fixed by Apple.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [ ] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/main/doc/contributing/pull_requests.md
