### PR TITLE
fix: iOS 17 negative lookahead regex bug

### DIFF
--- a/Beagle.podspec
+++ b/Beagle.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |spec|
 
   spec.name = "Beagle"
 
-  spec.version = '1.2.0'
+  spec.version = '2.0.3'
 
   spec.summary = "A framework to help implement Server-Driven UI in your apps natively."
   spec.description = <<-DESC

--- a/Sources/Beagle/Sources/ContextExpression/Expression/Parser.swift
+++ b/Sources/Beagle/Sources/ContextExpression/Expression/Parser.swift
@@ -97,7 +97,16 @@ let pathIndexNode: Parser<Path.Node> = zip(
     .index(int)
 }
 
-let pathKeyNode: Parser<Path.Node> = prefix(with: #"^\w+\b(?!\()"#).map { .key($0) }
+//let pathKeyNode: Parser<Path.Node> = prefix(with: #"^\w+\b(?!\()"#).map { .key($0) }
+let pathKeyNode = Parser<Path.Node> { str in
+    guard let keyNode = prefix(with: #"^\w+"#).run(&str) else { return nil }
+    if str.first == "(" {
+        str = keyNode[...] + str
+        return nil
+    } else {
+        return .key(keyNode)
+    }
+}
 
 let pathHeadNodes: Parser<[Path.Node]> = zip(
     zeroOrOne(pathKeyNode),


### PR DESCRIPTION
### Description and Example

Fixes a bug related to the negative lookahead iOS 17 bug, that prevents the parsing of simple expressions such as `@{context.value}`

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.
- [ ] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/main/doc/contributing/pull_requests.md
